### PR TITLE
Handle some not well formatted map links

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -27,6 +27,7 @@ class Scraper
             .split("#{EN_DASH} ")
             .map(&:strip)
 
+        # try increasingly degraded patterns to match ...
         if s.count == 3
           puts "Found 3 parts as expected: #{s.inspect}"
           reference = s[0]
@@ -42,9 +43,19 @@ class Scraper
           address = ::Regexp.last_match(2)
           description = ::Regexp.last_match(3)
           puts "Found reference #{reference.inspect}, address #{address.inspect} and description: #{description.inspect} [pattern #2]"
+        elsif s.count == 2 && name =~ %r{\A(\S+-\d\d\d\d[\s/]\d+)-?\s+(\S.{8,})#{EN_DASH}\s*(.*?)\z}
+          reference = ::Regexp.last_match(1)
+          address = ::Regexp.last_match(2)
+          description = ::Regexp.last_match(3)
+          puts "Found reference #{reference.inspect}, address #{address.inspect} and description: #{description.inspect} [pattern #3]"
+        elsif s.count == 2 && name =~ %r{\A(\S+-\d\d\d\d[\s/]\d+)\s*[-#{EN_DASH}]\s*([^-#{EN_DASH}]{15,})\s*[-#{EN_DASH}]\s*(.*?)\z}
+          reference = ::Regexp.last_match(1)
+          address = ::Regexp.last_match(2)
+          description = ::Regexp.last_match(3)
+          puts "Found reference #{reference.inspect}, address #{address.inspect} and description: #{description.inspect} [pattern #4]"
         else
           # Skip over unrecognized formats
-          puts "WARNING: Skipping unparsable map link: #{name.inspect}"
+          puts "WARNING: Skipping unparsable map link with #{s.count} parts: #{name.inspect}"
           skipped += 1
           next
         end


### PR DESCRIPTION
Fixes final problem mentioned on issue:
* https://github.com/planningalerts-scrapers/issues/issues/1080

Log on my dev system:
```
$ be ruby scraper.rb 
Found 3 parts as expected: ["PDPLANPMTD-2026-059001", "41 Germain Court, Sandford", "Dwelling & Secondary Residence"]
Found 3 parts as expected: ["PDPLANPMTD-2026-061945", "24 Creese Drive, Richmond", "Dwelling"]
Found 3 parts as expected: ["PDPLANPMTD-2025-057675", "242 Tranmere Road, Tranmere", "Additions & Alterations including Rectification Works (Single Dwelling)"]
Found 3 parts as expected: ["PDPLANPMTD-2026-061916", "59 Dolina Drive, Rokeby", "Dwelling"]
Found 3 parts as expected: ["PDPLANPMTD-2026-061386", "3 Pindos Drive, Tranmere", "Additions & Alterations (Single Dwelling)"]
Found 3 parts as expected: ["PDPLANPMTD-2026-061444", "10 Lowlynn Court, Geilston Bay", "Dwelling & Outbuilding"]
Found 3 parts as expected: ["PDPLANPMTD-2026-061649", "26 Meadows Place, Opossum Bay", "Additions & Alterations (Single Dwelling)"]
Found 3 parts as expected: ["PDPLANPMTD-2026-061844", "16 Blair Street, Richmond", "Carport (Single Dwelling)"]
Found 3 parts as expected: ["PDPLANPMTD-2026-061577", "1, 122 Cambridge Park Drive, Cambridge", "Change of Use to Car Rental (Bulky Goods & Sales)"]
Found 3 parts as expected: ["PDPLANPMTD-2026-060622", "3 Porpoise Close, Oakdowns", "Dwelling"]
Found 3 parts as expected: ["PDPLANPMTD-2026-058308", "113 Bayview Road, Lauderdale", "Additions & Alterations (Single Dwelling)"]
Found 3 parts as expected: ["PDPLANPMTD-2025-056316", "2 Elpida Street, Risdon Vale", "Three Lot Subdivision"]
Found 3 parts as expected: ["PDPLANPMTD-2026-062046", "53 Bayside Drive, Lauderdale", "Deck and Pool Addition (Single Dwelling)"]
Found 3 parts as expected: ["PDPLANPMTD-2026-061941", "5 Begonia Street, Lindisfarne", "Dwelling"]
Found 3 parts as expected: ["PDPLANPMTD-2026-058902", "32 Kennedy Drive, Cambridge with access from McRorie Court", "Signage, Seven Warehouses (Storage) and Car Rental Facility (Transport Depot & Distribution)"]
Found 3 parts as expected: ["PDPLANPMTD-2026-060465", "80 Bligh Street, Warrane", "Two Multiple Dwellings (One New & One Existing)"]
Found 3 parts as expected: ["PDPLANPMTD-2026-061998", "113 Spitfarm Road, Opossum Bay", "Deck & Swimming Pool (Single Dwelling)"]
Found reference "PDPLANPMTD-2026/061026", address "Dwelling " and description: "26 Creese Drive, RICHMOND" [pattern #3]
Found reference "PDPLANPMTD-2026/062229", address "Outbuilding (Single Dwelling) " and description: "5 Medlar Street, RISDON VALE" [pattern #4]
Found 3 parts as expected: ["PDPLANPMTD-2026/062062", "Change of Use to Community Meeting & Entertainment (Flight Simulator Business)", "7, 6 Kyeema Place, CAMBRIDGE"]
Found reference "PDPLANPMTD-2026/061627", address "Dwelling & Outbuilding (Single Dwelling)" and description: "5 Rainbow Terrace, OPOSSUM BAY" [pattern #4]
Found reference "PDPLANPMTD-2026/061352", address "Dwelling " and description: "194 Tollard Drive, ROKEBY" [pattern #3]
Found 3 parts as expected: ["PDPLANPMTD-2025/057996", "Additions & Alterations (Educational & Occasional Care)", "39,43 & 45 Currajong Street, MORNINGTON"]

Found 23 records, skipping 0 unrecognisable links
```