### PR TITLE
Add agent guidance files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# AGENTS.md
+
+This is one of the PlanningAlerts scrapers. Org-wide guidance for agents —
+issue tracking, PR conventions, review process, and scraper conventions —
+lives in the issues repo:
+
+https://github.com/planningalerts-scrapers/issues/blob/master/AGENTS.md
+
+Fetch and read that file before doing any work in this repo. Do not rely on a
+cached or remembered copy; it changes as org conventions evolve.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
Adds a stub `AGENTS.md` (and a `CLAUDE.md` that imports it) pointing agents at
the org-wide guidance in
[planningalerts-scrapers/issues](https://github.com/planningalerts-scrapers/issues/blob/master/AGENTS.md),
so agent guidance is maintained in one place.

Part of an org-wide rollout to all active scraper repos.